### PR TITLE
Solar bank interests simulator

### DIFF
--- a/BokInterface/BokInterface.Designer.cs
+++ b/BokInterface/BokInterface.Designer.cs
@@ -149,6 +149,13 @@ namespace BokInterface {
 				_memValuesListing.Close();
 				memValuesListingActive = false;
 			}
+
+			// Solar bank interests simulator
+			if (_solarBankInterestsSim != null) {
+				_solarBankInterestsSim.Controls.Clear();
+				_solarBankInterestsSim.Close();
+				solarBankInterestsSimActive = false;
+			}
 		}
 
 		/// <summary>Simplified method for setting the main window of the interface</summary>

--- a/BokInterface/all/WinFormHelpers.cs
+++ b/BokInterface/all/WinFormHelpers.cs
@@ -333,8 +333,9 @@ namespace BokInterface.All {
         /// <param name="width">Width (in pixels)</param>
         /// <param name="height">Height (in pixels)</param>
         /// <param name="control">Control instance if the element is to be attached to it directly</param>
+        /// <param name="dockStyle">DockStyle (by default None)</param>
         /// <returns><c>DataGridView</c>Instance</returns>
-        public static DataGridView CreateDataGridView(string name, DataTable data, int positionX, int positionY, int width, int height, Control? control = null) {
+        public static DataGridView CreateDataGridView(string name, DataTable data, int positionX, int positionY, int width, int height, Control? control = null, DockStyle dockStyle = DockStyle.None) {
 
             DataGridView gridView = new() {
                 Name = name,
@@ -347,7 +348,7 @@ namespace BokInterface.All {
                 Font = defaultFont,
                 AllowUserToAddRows = false,
                 AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill,
-                Dock = DockStyle.Fill,
+                Dock = dockStyle,
                 EnableHeadersVisualStyles = false,
                 ReadOnly = true
             };

--- a/BokInterface/subwindows/SubWindows.cs
+++ b/BokInterface/subwindows/SubWindows.cs
@@ -224,9 +224,11 @@ namespace BokInterface {
                         BoktaiToolsSubwindow();
                         break;
                     case "Zoktai":
+                        miscToolsSelectionWindow.Height = 145;
                         ZoktaiToolsSubwindow();
                         break;
                     case "Shinbok":
+                        miscToolsSelectionWindow.Height = 145;
                         ShinbokToolsSubwindow();
                         break;
                     case "LunarKnights":

--- a/BokInterface/subwindows/ToolsSelectSubWindow.cs
+++ b/BokInterface/subwindows/ToolsSelectSubWindow.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using BokInterface.All;
 using BokInterface.Tools.TileDataViewer;
 using BokInterface.Tools.MemoryValuesListing;
+using BokInterface.Tools.SolarBankInterestsSimulator;
 
 /**
  * Main file for tools selection subwindows
@@ -14,14 +15,16 @@ namespace BokInterface {
 
         #region Properties
 
-        protected bool tileDataViewerActive = false;
+        protected bool tileDataViewerActive = false,
+            memValuesListingActive = false,
+            solarBankInterestsSimActive = false;
         private TileDataViewer? _tileDataViewer;
-        protected bool memValuesListingActive = false;
         private MemoryValuesListing? _memValuesListing;
+        private SolarBankInterestsSimulator? _solarBankInterestsSim;
 
         #endregion
 
-        #region Subwindows methods for each game
+        #region Subwindows methods
 
         private void BoktaiToolsSubwindow() {
             AddToolsLabel();
@@ -33,12 +36,14 @@ namespace BokInterface {
             AddToolsLabel();
             AddTileDataViewerBtn();
             AddMemoryValuesListBtn();
+            AddSolarBankInterestsSimBtn();
         }
 
         private void ShinbokToolsSubwindow() {
             AddToolsLabel();
             AddTileDataViewerBtn();
             AddMemoryValuesListBtn();
+            AddSolarBankInterestsSimBtn();
         }
 
         private void LunarKnightsToolsSubwindow() {
@@ -47,7 +52,7 @@ namespace BokInterface {
 
         #endregion
 
-        #region Subwindow elements generating methods
+        #region Elements generation
 
         /// <summary>Simplified method for adding the label in the tools selection subwindow</summary>
 		/// <param name="posX">X position</param>
@@ -74,7 +79,6 @@ namespace BokInterface {
                 }
 
                 tileDataViewerActive = true;
-
                 switch (shorterGameName) {
                     case "Boktai":
                         _tileDataViewer = new BoktaiTileDataViewer(this, _boktaiAddresses);
@@ -126,7 +130,6 @@ namespace BokInterface {
                 }
 
                 memValuesListingActive = true;
-
                 switch (shorterGameName) {
                     case "Boktai":
                         _memValuesListing = new MemoryValuesListing(this, _boktaiAddresses);
@@ -155,6 +158,44 @@ namespace BokInterface {
             });
 
             miscToolsSelectionWindow.Controls.Add(mvlBtn);
+        }
+
+        /// <summary>Simplified method for adding the Solar bank interests simulator button to the tools selection subwindow</summary>
+		/// <param name="posX">X position</param>
+		/// <param name="posY">Y position</param>
+		/// <param name="width">Width (in pixels)</param>
+		/// <param name="height">Height (in pixels)</param>
+        private void AddSolarBankInterestsSimBtn(int posX = 5, int posY = 78, int width = 176, int height = 23) {
+
+            Button solarBankSimBtn = WinFormHelpers.CreateButton("solarBankInterestsSimBtn", "Solar bank interests simulator", posX, posY, width, height);
+            solarBankSimBtn.Click += new EventHandler(delegate (object sender, EventArgs e) {
+
+                // If tool is already active, stop
+                if (solarBankInterestsSimActive == true) {
+                    return;
+                }
+
+                solarBankInterestsSimActive = true;
+                switch (shorterGameName) {
+                    case "Zoktai":
+                    case "Shinbok":
+                        _solarBankInterestsSim = new SolarBankInterestsSimulator(this);
+                        break;
+                    default:
+                        // If game not handled, indicate that the tool isn't active & stop here
+                        solarBankInterestsSimActive = false;
+                        return;
+                }
+
+                // Add the on-close event handler
+                _solarBankInterestsSim.FormClosing += new FormClosingEventHandler(delegate (object sender, FormClosingEventArgs e) {
+                    // Indicate that the tool isn't active anymore & set instance to null just in case, to prevent it from doing anything else
+                    solarBankInterestsSimActive = false;
+                    _solarBankInterestsSim = null;
+                });
+            });
+
+            miscToolsSelectionWindow.Controls.Add(solarBankSimBtn);
         }
 
         #endregion

--- a/BokInterface/subwindows/weapons/ShinbokWeaponsEditor.cs
+++ b/BokInterface/subwindows/weapons/ShinbokWeaponsEditor.cs
@@ -370,7 +370,7 @@ namespace BokInterface.Weapons {
                 + "\r\n- SP effects that lowers resistance to an element will stack everytime the weapon is equipped (game bug)"
                 + "\r\n- These effects goes back to normal when switching rooms"
                 + "\r\n- If you want a weapon to have its proper attack pattern, set the refine for it",
-                5, 5, 611, 82, this, readOnly: true
+                5, 5, 611, 82, this
             );
         }
 

--- a/BokInterface/tools/MemoryValuesListing/MemoryValuesListing.cs
+++ b/BokInterface/tools/MemoryValuesListing/MemoryValuesListing.cs
@@ -106,7 +106,7 @@ namespace BokInterface.Tools.MemoryValuesListing {
             }
 
             // Show table in subwindow & set columns styles
-            _dataGridView = WinFormHelpers.CreateDataGridView("mvlGrid", _dataTable, 5, 5, ClientSize.Width - 10, ClientSize.Height - 10, this);
+            _dataGridView = WinFormHelpers.CreateDataGridView("mvlGrid", _dataTable, 5, 5, ClientSize.Width - 10, ClientSize.Height - 10, this, DockStyle.Fill);
             SetColumnsStyle();
         }
 

--- a/BokInterface/tools/SolarBankInterestsSimulator/SolarBankInterestsSimulator.cs
+++ b/BokInterface/tools/SolarBankInterestsSimulator/SolarBankInterestsSimulator.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Data;
+using System.Drawing;
+using System.Windows.Forms;
+
+using BokInterface.All;
+
+namespace BokInterface.Tools.SolarBankInterestsSimulator {
+    /// <summary>Class for the Solar bank interests simulator for Bok 2 and 3</summary>
+    class SolarBankInterestsSimulator : Form {
+
+        #region Properties
+
+        protected string name = "solarBankInterestsSimulator",
+            title = "Solar bank interests simulator";
+
+        private readonly DataTable _dataTable = new();
+        private DataGridView? _dataGridView;
+        private NumericUpDown _interestsRateNumDown = new(),
+            _baseSollsNumDown = new();
+        private Button _calculateInterestsBtn = new();
+
+        #endregion
+
+        #region Constructor
+
+        public SolarBankInterestsSimulator(BokInterface bokInterface) {
+            Owner = bokInterface;
+            Name = name;
+            Text = title;
+            AutoScaleDimensions = new SizeF(6F, 15F);
+            AutoScaleMode = AutoScaleMode.Inherit;
+            FormBorderStyle = FormBorderStyle.FixedSingle;
+            BackColor = SystemColors.Control;
+            Font = WinFormHelpers.defaultFont;
+            AutoScroll = true;
+            ClientSize = new Size(500, 208);
+
+            // Add elements & show the subwindow
+            AddControls();
+            Show();
+            ActiveControl = null;
+        }
+
+        /// <summary>Add the form control</summary>
+        private void AddControls() {
+            WinFormHelpers.CreateLabel("interestsRateLbl", "Interests rate", 5, 105, 80, 15, this, textAlignment: "MiddleRight");
+            WinFormHelpers.CreateLabel("baseSollsLbl", "Solls", 5, 132, 80, 15, this, textAlignment: "MiddleRight");
+            WinFormHelpers.CreateTextBox("info",
+                "Regarding interest and rate:"
+                + "\r\n- Interest accumulates when the day rolls over at midnight in-game."
+                + "\r\n- Up to 10 days when the date at game start is greater than the date on the save file."
+                + "\r\n- Rate is constant over multiple days of accumulation."
+                + "\r\n- Truncated when displayed at the bank (i.e. it may display 15%, but may actually be 15.7%)."
+                + "\r\n- Can be any value between 1% and ~21% (will only display as 20%).",
+                0, 0, ClientSize.Width, 98, this
+            );
+
+            _interestsRateNumDown = WinFormHelpers.CreateNumericUpDown("interestsRate", (decimal)1.70, 86, 103, 50, 23, maxValue: 21, nbDecimals: 2, control: this);
+            _baseSollsNumDown = WinFormHelpers.CreateNumericUpDown("baseSolls", 1000, 86, 130, 50, 23, maxValue: 9999, control: this);
+
+            _calculateInterestsBtn = WinFormHelpers.CreateButton("calculateInterestsBtn", "Calculate solar bank interests", 145, 103, 350, 50, this);
+            _calculateInterestsBtn.Click += new EventHandler(delegate (object sender, EventArgs e) {
+                GenerateDataTable();
+            });
+
+            // Generate empty data table at creation
+            GenerateDataTable();
+        }
+
+        #endregion
+
+        #region DataTable generation
+
+        /// <summary>Generate the Data Table containing the memory addresses, values and infos</summary>
+        private void GenerateDataTable() {
+
+            // Clear the table & subwindow
+            _dataTable.Columns.Clear();
+            _dataTable.Rows.Clear();
+            _dataTable.Clear();
+
+            // Generate table data for the current game
+            _dataGridView = WinFormHelpers.CreateDataGridView("interestsGrid", _dataTable, 0, 162, ClientSize.Width, 46, this);
+            _dataGridView.TopLeftHeaderCell.Value = "Day";
+            GenerateTableData();
+            SetColumnsStyle();
+        }
+
+        /// <summary>Set columns styles (width, text-alignment, ...)</summary>
+        private void SetColumnsStyle() {
+            if (_dataGridView != null) {
+                for (int i = 0; i < 10; i++) {
+                    if (_dataGridView.Columns.Contains((i + 1).ToString())) {
+                        _dataGridView.Columns[i].Width = 10;
+                        _dataGridView.Columns[i].DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
+                    }
+                }
+            }
+        }
+
+        /// <summary>Generate the table data</summary>
+        private void GenerateTableData() {
+
+            // Get values from fields
+            double currentSolls = (double)_baseSollsNumDown.Value;
+            double interestsRate = (double)_interestsRateNumDown.Value;
+
+            // Generate data
+            DataRow row = _dataTable.NewRow();
+            for (int i = 0; i < 10; i++) {
+
+                // Generate column
+                _dataTable.Columns.Add((i + 1).ToString());
+
+                // Calculate & add solls to column
+                double interests = currentSolls * interestsRate / 100;
+                currentSolls = Math.Floor(currentSolls + interests);
+                row[i] = currentSolls > 9999 ? 9999 : currentSolls;
+            }
+
+            _dataTable.Rows.Add(row);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Adds the Solar bank interests simulator for Boktai 2 & 3.
This allows to simulate the interests over 10 days for an adjustable interests rate and amount of solls.
![image](https://github.com/user-attachments/assets/9d585290-ab86-4273-86df-d39897898c1e)

This is based on datamined info from the [Bok 2 Game mechanics doc from Coa](https://docs.google.com/document/d/1ssoz0l0Mn_0WqlIPyarGZJV29x7_BGQ6Fw8WWiu0Ajs/edit?tab=t.0#heading=h.lu8mdbnisc6o).