### PR TITLE
Solar Bank interests simulator adjustments

### DIFF
--- a/BokInterface/tools/SolarBankInterestsSimulator/SolarBankInterestsSimulator.cs
+++ b/BokInterface/tools/SolarBankInterestsSimulator/SolarBankInterestsSimulator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Drawing;
 using System.Windows.Forms;
@@ -16,9 +17,24 @@ namespace BokInterface.Tools.SolarBankInterestsSimulator {
 
         private readonly DataTable _dataTable = new();
         private DataGridView? _dataGridView;
-        private NumericUpDown _interestsRateNumDown = new(),
-            _baseSollsNumDown = new();
+        private NumericUpDown _baseSollsNumDown = new();
         private Button _calculateInterestsBtn = new();
+        private ComboBox _interestsRateDropDown = new();
+        private readonly Dictionary<int, double> _interestsRates = new() {
+            {1, 1.562500},
+            {3, 3.125000},
+            {4, 4.687500},
+            {6, 6.250000},
+            {7, 7.812500},
+            {9, 9.375000},
+            {10, 10.937500},
+            {12, 12.500000},
+            {14, 14.062500},
+            {15, 15.625000},
+            {17, 17.187500},
+            {18, 18.750000},
+            {20, 20.312500}
+        };
 
         #endregion
 
@@ -57,7 +73,10 @@ namespace BokInterface.Tools.SolarBankInterestsSimulator {
                 0, 0, ClientSize.Width, 98, this
             );
 
-            _interestsRateNumDown = WinFormHelpers.CreateNumericUpDown("interestsRate", (decimal)1.70, 86, 103, 50, 23, 1, 21, 2, this);
+            _interestsRateDropDown = WinFormHelpers.CreateDropDownList("interestsRate", 86, 103, 50, 23, this, visibleOptions: 10);
+            _interestsRateDropDown.DataSource = new BindingSource(_interestsRates, null);
+            _interestsRateDropDown.DisplayMember = "Key";
+            _interestsRateDropDown.ValueMember = "Value";
             _baseSollsNumDown = WinFormHelpers.CreateNumericUpDown("baseSolls", 1000, 86, 130, 50, 23, 1, 9999, control: this);
 
             _calculateInterestsBtn = WinFormHelpers.CreateButton("calculateInterestsBtn", "Calculate solar bank interests", 145, 103, 350, 50, this);
@@ -104,8 +123,9 @@ namespace BokInterface.Tools.SolarBankInterestsSimulator {
         private void GenerateTableData() {
 
             // Get values from fields
+            KeyValuePair<int, double> selectedRate = (KeyValuePair<int, double>)_interestsRateDropDown.SelectedItem;
+            double interestsRate = selectedRate.Value;
             double currentSolls = (double)_baseSollsNumDown.Value;
-            double interestsRate = (double)_interestsRateNumDown.Value;
 
             // Generate data
             DataRow row = _dataTable.NewRow();

--- a/BokInterface/tools/SolarBankInterestsSimulator/SolarBankInterestsSimulator.cs
+++ b/BokInterface/tools/SolarBankInterestsSimulator/SolarBankInterestsSimulator.cs
@@ -67,9 +67,9 @@ namespace BokInterface.Tools.SolarBankInterestsSimulator {
                 "Regarding interest and rate:"
                 + "\r\n- Interest accumulates when the day rolls over at midnight in-game."
                 + "\r\n- Up to 10 days when the date at game start is greater than the date on the save file."
+                + "\r\n- The game also gives 1 Soll for free each time."
                 + "\r\n- Rate is constant over multiple days of accumulation."
-                + "\r\n- Truncated when displayed at the bank (i.e. it may display 15%, but may actually be 15.7%)."
-                + "\r\n- Can be any value between 1% and ~21% (will only display as 20%).",
+                + "\r\n- Truncated when displayed at the bank (i.e. it may display 15%, but may actually be 15.7%).",
                 0, 0, ClientSize.Width, 98, this
             );
 
@@ -134,9 +134,12 @@ namespace BokInterface.Tools.SolarBankInterestsSimulator {
                 // Generate column
                 _dataTable.Columns.Add((i + 1).ToString());
 
-                // Calculate & add solls to column
+                /**
+                 * Calculate & add solls to column
+                 * Note: the game gives 1 extra soll each day (up to 10 days)
+                 */
                 double interests = currentSolls * interestsRate / 100;
-                currentSolls = Math.Floor(currentSolls + interests);
+                currentSolls = Math.Floor(currentSolls + interests) + 1;
                 row[i] = currentSolls > 9999 ? 9999 : currentSolls;
             }
 


### PR DESCRIPTION
Fixes a few things regarding Solar Bank interests based on in-game mechanics:
- The interest rate is not a random number between 1 & 21%, instead the game chooses between set values (for example "20.312500%")
- Each time the interests gets added to the amount in bank, the game also gives 1 extra Soll (up to 10 days).